### PR TITLE
Add ChatGPT Notion connector boilerplate

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,30 @@
-# chatgpt-notion-connector
+# ChatGPT Notion Connector
+
+This repository contains a minimal boilerplate for integrating the Notion API with OpenAI's ChatGPT API. The example code demonstrates how to search a Notion workspace and use ChatGPT to select relevant pages based on a natural language query.
+
+## Setup
+
+1. Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+2. Set the required environment variables:
+
+- `NOTION_TOKEN` – Notion integration token.
+- `OPENAI_API_KEY` – OpenAI API key.
+
+You can export them in your shell or create a `.env` file and load it before running the script.
+
+## Usage
+
+Run a search query against your connected Notion workspace:
+
+```bash
+python -m src.main "<your search query>"
+```
+
+The script performs a basic Notion search and then asks ChatGPT to pick the most relevant pages from the results.
+
+This project is only a starting point and does not provide advanced search features or error handling. Use it as a foundation for building a more complete connector.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+notion-client
+openai

--- a/src/chatgpt_search.py
+++ b/src/chatgpt_search.py
@@ -1,0 +1,29 @@
+import os
+from typing import List, Dict, Any
+
+import openai
+
+
+def search_with_chatgpt(query: str, pages: List[Dict[str, Any]], model: str = "gpt-3.5-turbo") -> str:
+    """Use ChatGPT to perform semantic search over Notion page contents.
+
+    This is a simple implementation that feeds the list of page titles to the
+    model and asks it to select the most relevant ones.
+    """
+    openai.api_key = os.getenv("OPENAI_API_KEY")
+    if not openai.api_key:
+        raise ValueError("OPENAI_API_KEY environment variable must be set")
+
+    content = "\n".join(page.get("title", "") for page in pages)
+    prompt = (
+        "You are a helpful assistant that helps search Notion pages.\n"
+        f"User query: {query}\n"
+        "Available pages:\n" + content + "\n"
+        "Return the titles of the most relevant pages."
+    )
+
+    response = openai.ChatCompletion.create(
+        model=model,
+        messages=[{"role": "user", "content": prompt}],
+    )
+    return response["choices"][0]["message"]["content"]

--- a/src/main.py
+++ b/src/main.py
@@ -1,0 +1,26 @@
+from .notion_connector import NotionConnector
+from .chatgpt_search import search_with_chatgpt
+
+
+def main(query: str) -> None:
+    notion = NotionConnector()
+    pages = notion.search(query)
+
+    # Format pages as simple dicts with title and id for demonstration
+    formatted = []
+    for page in pages:
+        title = page.get('properties', {}).get('title', {}).get('title', [])
+        title_text = title[0]['plain_text'] if title else 'Untitled'
+        formatted.append({'id': page['id'], 'title': title_text})
+
+    result = search_with_chatgpt(query, formatted)
+    print(result)
+
+
+if __name__ == "__main__":
+    import sys
+
+    if len(sys.argv) < 2:
+        print("Usage: python -m src.main '<query>'")
+    else:
+        main(sys.argv[1])

--- a/src/notion_connector.py
+++ b/src/notion_connector.py
@@ -1,0 +1,23 @@
+import os
+from typing import List, Dict, Any
+from notion_client import Client
+
+class NotionConnector:
+    """Simple wrapper around the Notion API."""
+
+    def __init__(self, token: str | None = None) -> None:
+        self.token = token or os.getenv("NOTION_TOKEN")
+        if not self.token:
+            raise ValueError(
+                "Notion API token must be provided via argument or NOTION_TOKEN env variable"
+            )
+        self.client = Client(auth=self.token)
+
+    def search(self, query: str) -> List[Dict[str, Any]]:
+        """Perform a search across the workspace."""
+        response = self.client.search(query=query)
+        return response.get("results", [])
+
+    def get_page_content(self, page_id: str) -> Dict[str, Any]:
+        """Retrieve page JSON content."""
+        return self.client.pages.retrieve(page_id)


### PR DESCRIPTION
## Summary
- add minimal README with setup instructions
- implement NotionConnector wrapper for Notion API
- implement ChatGPT search utility
- provide example script and package init
- add requirements

## Testing
- `pytest -q`
- `python -m src.main 'test query'` *(fails: ModuleNotFoundError: No module named 'notion_client')*

------
https://chatgpt.com/codex/tasks/task_b_6844bbef33188322b015b4d69add2fb2